### PR TITLE
[bugfix] only return original data

### DIFF
--- a/ABify/helpers/csv_writer.rb
+++ b/ABify/helpers/csv_writer.rb
@@ -14,14 +14,13 @@ class CSVWriter
 
   def write_import_results(results)
     headers = ['Status']
-    response_steps = gather_response_steps(results[:data])
+    response_steps = gather_response_steps(results[:rows])
     headers.concat(response_steps.map { |step| "Response (#{step})" })
-    data_keys = gather_data_keys(results[:data])
+    data_keys = gather_data_keys(results[:rows])
     headers.concat(data_keys)
-
     CSV.open(@file_path, 'w') do |csv|
       csv << headers
-      results[:data].each do |row|
+      results[:rows].each do |row|
         csv << build_row(headers, row, response_steps)
       end
     end

--- a/ABify/models/data_sources/data_source.rb
+++ b/ABify/models/data_sources/data_source.rb
@@ -25,10 +25,4 @@ class DataSource
   def failed_row_count
     @rows.select { |row| row.status == 'error' }.count
   end
-
-  protected
-
-  def store_original_data
-    @original_data = summary(data: true)
-  end
 end

--- a/ABify/models/data_sources/data_source.rb
+++ b/ABify/models/data_sources/data_source.rb
@@ -3,16 +3,14 @@
 # Base class for data sources
 # There can be multiple data sources, each with their own implementation
 class DataSource
-  attr_reader :original_data
-
   # Placeholder method to be handled by subclasses
   def rows
     raise NotImplementedError, 'Subclasses must implement a rows method'
   end
 
-  def summary(data: false)
-    if data
-      @rows.map { |row| row.summary(data: data) }
+  def summary(data: false, original_data: false)
+    if data || original_data
+      @rows.map { |row| row.summary(data: data, original_data: original_data) }
     else
       @rows.select { |row| row.requests.length > 1 }.map { |row| row.summary(data: data) }
     end

--- a/ABify/models/data_sources/data_source.rb
+++ b/ABify/models/data_sources/data_source.rb
@@ -3,7 +3,9 @@
 # Base class for data sources
 # There can be multiple data sources, each with their own implementation
 class DataSource
-  # Placeholder method to be implemented by subclasses
+  attr_reader :original_data
+
+  # Placeholder method to be handled by subclasses
   def rows
     raise NotImplementedError, 'Subclasses must implement a rows method'
   end
@@ -22,5 +24,11 @@ class DataSource
 
   def failed_row_count
     @rows.select { |row| row.status == 'error' }.count
+  end
+
+  protected
+
+  def store_original_data
+    @original_data = summary(data: true)
   end
 end

--- a/ABify/models/data_sources/mock_data_source.rb
+++ b/ABify/models/data_sources/mock_data_source.rb
@@ -16,6 +16,8 @@ class MockData < DataSource
       generator = method(:mock_create_customers)
     when 'deleteCustomers'
       generator = method(:mock_delete_customers)
+    when 'createSubscriptions'
+      generator = method(:mock_create_subscriptions)
     else
       raise "Unknown template: #{template}"
     end
@@ -52,6 +54,20 @@ class MockData < DataSource
   def mock_delete_customers
     {
       'customer reference' => Faker::Alphanumeric.alphanumeric(number: 10)
+    }
+  end
+
+  def mock_create_subscriptions
+    next_billing = (Date.today + rand(1..30))
+    {
+      'customer reference' => 'test',
+      'subscription reference' => Faker::Alphanumeric.alphanumeric(number: 8),
+      'product' => 'freemo',
+      'next billing at' => next_billing.strftime('%Y-%m-%d'),
+      'previous billing at' => (next_billing - 30).strftime('%Y-%m-%d'),
+      'component 1' => %w[recurring metered].sample,
+      'component price point 1' => %w[original standard].sample,
+      'component quantity 1' => rand(1..100)
     }
   end
 end

--- a/ABify/models/data_sources/row.rb
+++ b/ABify/models/data_sources/row.rb
@@ -6,7 +6,7 @@ class Row
 
   def initialize(data, index = nil)
     @data = data
-    @original_data = data
+    @original_data = data.dup
     @index = index
     @status = nil
     @errors = []

--- a/ABify/models/data_sources/row.rb
+++ b/ABify/models/data_sources/row.rb
@@ -2,10 +2,11 @@
 
 # A row of data from a data source
 class Row
-  attr_accessor :data, :status, :errors, :requests, :responses, :index
+  attr_accessor :data, :status, :errors, :requests, :responses, :index, :original_data
 
   def initialize(data, index = nil)
     @data = data
+    @original_data = data
     @index = index
     @status = nil
     @errors = []
@@ -13,7 +14,7 @@ class Row
     @responses = []
   end
 
-  def summary(data: false)
+  def summary(data: false, original_data: false)
     summary = {
       index: @index,
       status: @status,
@@ -22,6 +23,7 @@ class Row
       responses: @responses
     }
     summary[:data] = @data if data
+    summary[:data] = @original_data if original_data
     summary
   end
 end

--- a/ABify/models/importer.rb
+++ b/ABify/models/importer.rb
@@ -56,7 +56,7 @@ class Importer
       failed_rows: @data.failed_row_count,
       subdomain: @config.subdomain,
       domain: @config.domain,
-      data: @data.summary(data: data, original_data: original_data)
+      rows: @data.summary(data: data, original_data: original_data)
     }
   end
 

--- a/ABify/models/importer.rb
+++ b/ABify/models/importer.rb
@@ -42,7 +42,7 @@ class Importer
     puts "\n\ngreat job"
   end
 
-  def summary(data: true)
+  def summary(data: false, original_data: true)
     end_time = @completed_at || Time.now
     run_time = duration(@created_at, end_time)
     {
@@ -56,7 +56,7 @@ class Importer
       failed_rows: @data.failed_row_count,
       subdomain: @config.subdomain,
       domain: @config.domain,
-      data: @data.summary(data: data)
+      data: @data.summary(data: data, original_data: original_data)
     }
   end
 

--- a/ABify/payloads/subscriptions/create_subscriptions.rb
+++ b/ABify/payloads/subscriptions/create_subscriptions.rb
@@ -55,7 +55,7 @@ module Payloads
       end
 
       def self.payment_profile_id(row)
-        return if row['group payer'] != 'self' || true?(row['subscription group'])
+        return if (present?(row['group payer']) && row['group payer'] != 'self') || true?(row['subscription group'])
 
         row['payment profile id']
       end

--- a/ABify/spec/controllers/importer_controller_spec.rb
+++ b/ABify/spec/controllers/importer_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
 require 'rack/test'
+require_relative '../spec_helper'
 require_relative '../../controllers/importer_controller'
 require_relative '../../models/importer'
 require_relative '../../workflows/build_workflow'

--- a/ABify/spec/helpers/csv_writer_spec.rb
+++ b/ABify/spec/helpers/csv_writer_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
 require 'csv'
+require_relative '../spec_helper'
 require_relative '../../helpers/csv_writer'
 
 RSpec.describe CSVWriter do

--- a/ABify/spec/helpers/csv_writer_spec.rb
+++ b/ABify/spec/helpers/csv_writer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CSVWriter do
       failed_rows: 0,
       subdomain: 'luke',
       domain: 'chargify.com',
-      data: [
+      rows: [
         {
           index: 1,
           status: 'complete',

--- a/ABify/spec/models/buffer_step_spec.rb
+++ b/ABify/spec/models/buffer_step_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require_relative '../spec_helper'
 require_relative '../../models/buffer_step'
 
 RSpec.describe BufferStep do

--- a/ABify/spec/models/config_spec.rb
+++ b/ABify/spec/models/config_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require_relative '../spec_helper'
 require_relative '../../models/config'
 
 RSpec.describe Config do

--- a/ABify/spec/models/data_sources/row_spec.rb
+++ b/ABify/spec/models/data_sources/row_spec.rb
@@ -45,9 +45,11 @@ RSpec.describe Row do
     end
 
     it 'includes original data when original_data option is true' do
-      row.data = { 'modified' => true }
+      row.data['name'] = 'New Name'
       summary = row.summary(original_data: true)
-      expect(summary[:data]).to eq(data)
+      expect(summary[:data]).to eq({ 'name' => 'Test User', 'email' => 'test@example.com' })
+      expect(row.data['name']).to eq('New Name')
+      expect(row.original_data['name']).to eq('Test User')
     end
   end
 end

--- a/ABify/spec/models/data_sources/row_spec.rb
+++ b/ABify/spec/models/data_sources/row_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+require_relative '../../../models/data_sources/row'
+
+RSpec.describe Row do
+  let(:data) { { 'name' => 'Test User', 'email' => 'test@example.com' } }
+  let(:index) { 1 }
+  subject(:row) { described_class.new(data, index) }
+
+  describe '#initialize' do
+    it 'sets initial values' do
+      expect(row.data).to eq(data)
+      expect(row.original_data).to eq(data)
+      expect(row.index).to eq(index)
+      expect(row.status).to be_nil
+      expect(row.errors).to be_empty
+      expect(row.requests).to be_empty
+      expect(row.responses).to be_empty
+    end
+  end
+
+  describe '#summary' do
+    before do
+      row.status = 'completed'
+      row.errors << 'Test error'
+      row.requests << 'GET /test'
+      row.responses << '200 OK'
+    end
+
+    it 'returns basic summary without data by default' do
+      summary = row.summary
+
+      expect(summary[:index]).to eq(index)
+      expect(summary[:status]).to eq('completed')
+      expect(summary[:errors]).to eq(['Test error'])
+      expect(summary[:requests]).to eq(['GET /test'])
+      expect(summary[:responses]).to eq(['200 OK'])
+      expect(summary[:data]).to be_nil
+    end
+
+    it 'includes current data when data option is true' do
+      summary = row.summary(data: true)
+      expect(summary[:data]).to eq(data)
+    end
+
+    it 'includes original data when original_data option is true' do
+      row.data = { 'modified' => true }
+      summary = row.summary(original_data: true)
+      expect(summary[:data]).to eq(data)
+    end
+  end
+end

--- a/ABify/spec/models/hydra_logger_spec.rb
+++ b/ABify/spec/models/hydra_logger_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
 require 'logger'
+require_relative '../spec_helper'
 require_relative '../../models/hydra_logger'
 
 RSpec.describe HydraLogger do

--- a/ABify/spec/models/importer_spec.rb
+++ b/ABify/spec/models/importer_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
 require 'typhoeus'
+require_relative '../spec_helper'
 require_relative '../../models/importer'
 
 RSpec.describe Importer do

--- a/ABify/spec/models/importer_spec.rb
+++ b/ABify/spec/models/importer_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Importer do
         failed_rows: data.failed_row_count,
         subdomain: config.subdomain,
         domain: config.domain,
-        data: data.summary(data: true)
+        rows: data.summary(data: true)
       }
 
       expect(summary).to include(expected_summary)

--- a/ABify/spec/models/step_callback_handler_spec.rb
+++ b/ABify/spec/models/step_callback_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
 require 'typhoeus'
+require_relative '../spec_helper'
 require_relative '../../models/step_callback_handler'
 
 RSpec.describe StepCallbackHandler do

--- a/ABify/spec/models/step_spec.rb
+++ b/ABify/spec/models/step_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require_relative '../spec_helper'
 require_relative '../../models/step'
 
 RSpec.describe Step do

--- a/ABify/spec/payloads/customers_spec.rb
+++ b/ABify/spec/payloads/customers_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require_relative '../spec_helper'
 require_relative '../../payloads/customers'
 
 RSpec.describe Payloads::Customers do

--- a/ABify/spec/payloads/subscriptions/create_subscriptions_spec.rb
+++ b/ABify/spec/payloads/subscriptions/create_subscriptions_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require_relative '../../spec_helper'
 require_relative '../../../payloads/subscriptions/create_subscriptions'
 
 RSpec.describe Payloads::Subscriptions::CreateSubscriptions do

--- a/ABify/spec/workflows/customers/delete_customers_spec.rb
+++ b/ABify/spec/workflows/customers/delete_customers_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require_relative '../../spec_helper'
 require_relative '../../../workflows/customers/delete_customers'
 
 RSpec.describe DeleteCustomers do

--- a/ABify/workflows/subscriptions/create_subscriptions.rb
+++ b/ABify/workflows/subscriptions/create_subscriptions.rb
@@ -37,8 +37,12 @@ class CreateSubscriptions < Workflow
       method: :get,
       url: ->(row, config) { "#{config.base_url}/payment_profiles.json?customer_id=#{row['customer id']}" },
       response_key: 'payment profile id',
-      response_val: ->(result) { result.last['payment_profile']['id'] }
+      response_val: ->(result) { last_payment_profile_id(result) }
     }
+  end
+
+  def last_payment_profile_id(result)
+    result.max_by { |profile| profile['payment_profile']['id'].to_i }['payment_profile']['id'] if result.any?
   end
 
   def create_subscription_step

--- a/Apps-Script/aaatest.js
+++ b/Apps-Script/aaatest.js
@@ -14,6 +14,6 @@ function test(siteName, template) {
   importer.sheet.filterActiveRows();
   importer.start();
   const result = importer.monitor();
-  importer.sheet.writeImportResults(result.data);
+  importer.sheet.writeImportResults(result.rows);
   Logger.log('great job');
 }

--- a/Apps-Script/server/app.js
+++ b/Apps-Script/server/app.js
@@ -11,7 +11,7 @@ function startImporter(args) {
   importer.sheet.filterActiveRows();
   importer.start();
   const result = importer.monitor();
-  importer.sheet.writeImportResults(result.data);
+  importer.sheet.writeImportResults(result.rows);
   return JSON.stringify(result);
 }
 


### PR DESCRIPTION
https://github.com/imlukedewitt/ABify/issues/6

WHAT:
The results CSV should not include any info from step results, only the data from the original input csv

HOW:
in the Row model, added class variable @original_data. This is a duplicate of the row's data, created when the row is initialized